### PR TITLE
16-divergent-history-seems-to-confuse-the-git-count

### DIFF
--- a/powerbash.sh
+++ b/powerbash.sh
@@ -195,10 +195,10 @@ __powerbash() {
 
     # how many commits local branch is ahead/behind of remote?
     local stat="$(git rev-list --left-right --boundary @{u}... 2>/dev/null)"
-    local aheadN="$(echo $stat | grep -o ">" -c)"
-    local behindN="$(echo $stat | grep -o "<" -c)"
-    [ "$aheadN" -gt 0 ] && marks+=" $POWERBASH_GIT_NEED_PUSH_SYMBOL$aheadN"
-    [ "$behindN" -gt 0 ] && marks+=" $POWERBASH_GIT_NEED_PULL_SYMBOL$behindN"
+    local aheadN=${stat//[^>]}
+    local behindN=${stat//[^<]}
+    [ "${#aheadN}" -gt 0 ] && marks+=" $POWERBASH_GIT_NEED_PUSH_SYMBOL${#aheadN}"
+    [ "${#behindN}" -gt 0 ] && marks+=" $POWERBASH_GIT_NEED_PULL_SYMBOL${#behindN}"
 
     printf "$COLOR_GIT $POWERBASH_GIT_BRANCH_SYMBOL$branch$marks $RESET"
   }


### PR DESCRIPTION
When capturing the git rev-list output, the line returns were getting mangled and resulting in a single line thereby messing up the subsequent grep statements.

When piping rev-list directly to grep it worked fine. However when capturing the output to grep later, it was a single line and only ever seeing a single entry. I'm still not sure why that is the case. We could, of course, make the rev-list call multiple times performing multiple greps (which worked), but I didn't like the idea of running the git command more than absolutely necessary.

Using some bash variable "tricks", I'm now filtering everything except "<" and ">" respectively and then counting the number of characters in the string.