### PR TITLE
fix global installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ And source it in '~/.bashrc' for your user account
 
 Download the Bash script
 
-    sudo curl -Ls https://raw.githubusercontent.com/napalm255/powerbash/master/powerbash.sh > /etc/profile.d/z_powerbash.sh
+    sudo curl -Ls https://raw.githubusercontent.com/napalm255/powerbash/master/powerbash.sh -o /etc/profile.d/z_powerbash.sh
 
 Note:
 


### PR DESCRIPTION
The README install instructions use `sudo` for root privileges, but then use the print (`>`) ability to write to a file. This write operation does not gain sudo privileges.

I've written the file with a curl option instead.