### PR TITLE
make POWERBASH_CONFIG ~/.config/powerbashrc

### DIFF
--- a/powerbash.sh
+++ b/powerbash.sh
@@ -345,7 +345,7 @@ __powerbash
 unset __powerbash
 
 # load saved configuration
-POWERBASH_CONFIG="$HOME/.powerbash_config"
+POWERBASH_CONFIG="$HOME/.config/powerbashrc"
 [[ -e "$POWERBASH_CONFIG" ]] && __powerbash_config load
 
 # enable auto completion


### PR DESCRIPTION
Most settings are in `~/.config` nowadays, otherwise the dot-files make a messy ~.