### PR TITLE
There are other common use cases for PROMPT_COMMAND than setting PS1.…

### DIFF
--- a/powerbash.sh
+++ b/powerbash.sh
@@ -357,7 +357,7 @@ __powerbash() {
     elif [[ "${PROMPT_COMMAND}" == *"__powerbash_set_ps1"* ]]; then
       PROMPT_COMMAND="$(sed -E "s/__powerbash_set_ps1 [a-z]+/__powerbash_set_ps1 $1/" <<< ${PROMPT_COMMAND})"
     else
-      PROMPT_COMMAND="__powerbash_set_ps1 $1;${PROMPT_COMMAND}"
+      PROMPT_COMMAND="${PROMPT_COMMAND};__powerbash_set_ps1 $1"
     fi
   }
 

--- a/powerbash.sh
+++ b/powerbash.sh
@@ -8,7 +8,7 @@ powerbash() {
     reload) source ~/.bashrc ;;
     prompt)
       case "$2" in
-        on|off|system) export PROMPT_COMMAND="__powerbash_ps1 $2" ;;
+        on|off|system) __powerbash_set_prompt_command $2 ;;
         *) echo "invalid option" ;;
       esac
     ;;
@@ -307,7 +307,7 @@ __powerbash() {
     [ $1 -ne 0 ] && printf "$COLOR_RC $1 $RESET"
   }
 
-  __powerbash_ps1() {
+  __powerbash_set_ps1() {
     # keep this at top!!!
     # capture latest return code
     local RETURN_CODE=$?
@@ -334,7 +334,34 @@ __powerbash() {
     esac
   }
 
-  PROMPT_COMMAND="__powerbash_ps1 on"
+  __powerbash_set_prompt_command() {
+    # Play nice with other scripts that may also use PROMPT_COMMAND,
+    # such as direnv and vte_prompt_command.
+    if [[ -z "${PROMPT_COMMAND}" ]]; then
+      PROMPT_COMMAND="__powerbash_set_ps1 $1"
+    elif [[ "$(declare -p PROMPT_COMMAND 2>&1)" =~ "declare -a" ]]; then
+      # If PROMPT_COMMAND is an array (supported as of bash 5.1),
+      # then an item is added or the existing one is modified.
+      local _i_prompt_cmd
+      local _prompt_cmd_changed="no"
+      for ((_i_prompt_cmd=0; _i_prompt_cmd<${#PROMPT_COMMAND[@]}; _i_prompt_cmd++)); do
+        if [[ "${PROMPT_COMMAND[$_i_prompt_cmd]}" =~ "__powerbash_set_ps1" ]]; then
+          PROMPT_COMMAND[$_i_prompt_cmd]="__powerbash_set_ps1 $1"
+          _prompt_cmd_changed="yes"
+        fi
+      done
+      # No existing array element has been changed, so add a new one.
+      if [[ ${_prompt_cmd_changed} == "no" ]]; then
+        PROMPT_COMMAND+=("__powerbash_set_ps1 $1")
+      fi
+    elif [[ "${PROMPT_COMMAND}" == *"__powerbash_set_ps1"* ]]; then
+      PROMPT_COMMAND="$(sed -E "s/__powerbash_set_ps1 [a-z]+/__powerbash_set_ps1 $1/" <<< ${PROMPT_COMMAND})"
+    else
+      PROMPT_COMMAND="__powerbash_set_ps1 $1;${PROMPT_COMMAND}"
+    fi
+  }
+
+  __powerbash_set_prompt_command on
 }
 
 # save system PS1


### PR DESCRIPTION
There are other common use cases for PROMPT_COMMAND than setting PS1. For example:

- [`direnv`](https://direnv.net/) loads rc files upon a change of directory
- `/etc/profile.d/vte.sh` also sets this variable on some operating systems, e.g. Fedora Linux, to make it possible to open new virtual terminal tabs in the same directory as the current one.

On my system, before loading powerbash:

```bash
echo ${PROMPT_COMMAND}
```

gives

```
_direnv_hook;__vte_prompt_command
```

The modified code keeps existing settings. They are extended instead of overwritten when loading powerbash. As of Bash 5.1, PROMPT_COMMAND can be an array, which is also supported in this change.

Note that the `export` from `export PROMPT_COMMAND` was removed. When PROMPT_COMMAND is an array (newer bash versions) it cannot be exported, so one should not rely on it. This also means, at least on most Linux systems, that powerbash should be enabled in `.bashrc`, not `.bash_profile`. One cannot assume that the PROMPT_COMMAND array persists in subprocess, so it needs to be reinitialized every time bash starts. (The installer script puts it in .bash_profile, which did not work for me.)